### PR TITLE
Removed unnecessary context from API. It can be deducted from request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@ server := niso.NewServer(niso.NewServerConfig(), storage.NewExampleStorage())
 
 // Authorization code endpoint
 http.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
-    ctx := context.TODO()
-
     resp, err := server.HandleHTTPAuthorizeRequest(
-        ctx,
         r,
         func(ar *niso.AuthorizationRequest) (bool, error) {
             return true, nil
@@ -39,10 +36,7 @@ http.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
 
 // Access token endpoint
 http.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
-    ctx := context.TODO()
-
     resp, err := server.HandleHTTPAccessRequest(
-        ctx,
         r,
         func(ar *niso.AccessRequest) (bool, error) {
             return true, nil

--- a/access.go
+++ b/access.go
@@ -126,7 +126,8 @@ type AccessTokenGenerator interface {
 // HandleHTTPAccessRequest is the main entry point for handling access requests.
 // This method will always return a Response, even if there was an error processing the request, which should be
 // rendered for a user. It may also return an error in the second argument which can be logged by the caller.
-func (s *Server) HandleHTTPAccessRequest(ctx context.Context, r *http.Request, isAuthorizedCb AccessRequestAuthorizedCallback) (*Response, error) {
+func (s *Server) HandleHTTPAccessRequest(r *http.Request, isAuthorizedCb AccessRequestAuthorizedCallback) (*Response, error) {
+	ctx := r.Context()
 	ar, err := s.GenerateAccessRequest(ctx, r)
 	if err != nil {
 		return toInternalError(err).AsResponse(), err

--- a/access_test.go
+++ b/access_test.go
@@ -63,9 +63,7 @@ func TestAccessPassword(t *testing.T) {
 	req.Form.Set("password", "testing")
 	req.Form.Set("state", "a")
 
-	ctx := context.TODO()
 	resp, err := server.HandleHTTPAccessRequest(
-		ctx,
 		req,
 		func(ar *AccessRequest) (bool, error) {
 			return ar.Username == "testing" && ar.Password == "testing", nil

--- a/authorize.go
+++ b/authorize.go
@@ -210,9 +210,9 @@ func errorWithRedirect(ar *AuthorizationRequest, err error) error {
 // HandleHTTPAuthorizeRequest is the main entry point for handling authorization requests.
 // This method will always return a Response, even if there was an error processing the request, which should be
 // rendered for a user. It may also return an error in the second argument which can be logged by the caller.
-func (s *Server) HandleHTTPAuthorizeRequest(ctx context.Context, r *http.Request, isAuthorizedCb AuthRequestAuthorizedCallback) (*Response, error) {
+func (s *Server) HandleHTTPAuthorizeRequest(r *http.Request, isAuthorizedCb AuthRequestAuthorizedCallback) (*Response, error) {
 	return s.HandleAuthorizeRequest(
-		ctx,
+		r.Context(),
 		func() (*AuthorizationRequest, error) {
 			return authorizationRequestFromHTTPRequest(r), nil
 		},

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -40,9 +40,7 @@ func TestAuthorizeCodeAccessDenied(t *testing.T) {
 
 	req := makeAuthorizeTestRequest(t, ResponseTypeCode)
 
-	ctx := context.TODO()
 	resp, err := server.HandleHTTPAuthorizeRequest(
-		ctx,
 		req,
 		func(_ *AuthorizationRequest) (bool, error) { return false, nil },
 	)

--- a/example/simple.go
+++ b/example/simple.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"log"
 	"net/http"
 

--- a/example/simple.go
+++ b/example/simple.go
@@ -14,10 +14,7 @@ func main() {
 
 	// Authorization code endpoint
 	http.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.TODO()
-
 		resp, err := server.HandleHTTPAuthorizeRequest(
-			ctx,
 			r,
 			func(ar *niso.AuthorizationRequest) (bool, error) {
 				return true, nil
@@ -32,10 +29,7 @@ func main() {
 
 	// Access token endpoint
 	http.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.TODO()
-
 		resp, err := server.HandleHTTPAccessRequest(
-			ctx,
 			r,
 			func(ar *niso.AccessRequest) (bool, error) {
 				return true, nil

--- a/integration_test.go
+++ b/integration_test.go
@@ -34,10 +34,7 @@ func (s *NisoIntegrationTestSuite) SetupSuite() {
 	server.Storage = newIntegrationTestStorage()
 
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.TODO()
-
 		resp, err := server.HandleHTTPAuthorizeRequest(
-			ctx,
 			r,
 			func(_ *AuthorizationRequest) (bool, error) { return true, nil },
 		)
@@ -50,9 +47,7 @@ func (s *NisoIntegrationTestSuite) SetupSuite() {
 	s.testAuthorizeURL = authServer.URL
 
 	accessServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.TODO()
 		resp, err := server.HandleHTTPAccessRequest(
-			ctx,
 			r,
 			func(_ *AccessRequest) (bool, error) { return true, nil },
 		)


### PR DESCRIPTION
Sorry dude for breaking API ))): Better now than later.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>